### PR TITLE
netbuf: Fix use-after-free when trimming from the beginning

### DIFF
--- a/fnet_stack/stack/fnet_netbuf.c
+++ b/fnet_stack/stack/fnet_netbuf.c
@@ -496,14 +496,13 @@ void _fnet_netbuf_trim( fnet_netbuf_t **nb_ptr, fnet_int32_t len )
     fnet_netbuf_t   *nb;
     fnet_size_t     tot_len;
     fnet_size_t     total_rem;
-    fnet_netbuf_t   *tmp_nb;
+    fnet_flag_t     tmp_flags;
 
     if(len == 0)
     {
         return;
     }
 
-    tmp_nb = (fnet_netbuf_t *) *nb_ptr;
     nb = (fnet_netbuf_t *) *nb_ptr;
     head_nb = nb;
 
@@ -518,6 +517,9 @@ void _fnet_netbuf_trim( fnet_netbuf_t **nb_ptr, fnet_int32_t len )
 
     if(len > 0) /* Trim len bytes from the begin of the buffer.*/
     {
+        /* If we delete the head_nb, we want to carry forward the flags */
+        tmp_flags = nb->flags;
+
         while((nb != 0) && ((fnet_size_t)len >= tot_len))
         {
             *nb_ptr = nb->next;
@@ -534,7 +536,7 @@ void _fnet_netbuf_trim( fnet_netbuf_t **nb_ptr, fnet_int32_t len )
             nb->data_ptr = (fnet_uint8_t *)nb->data_ptr + /* Or change pointer. */
                            nb->length - (tot_len - (fnet_size_t)len);
             nb->length = tot_len - (fnet_size_t)len;
-            nb->flags = tmp_nb->flags;
+            nb->flags = tmp_flags;
         }
     }
     else /* Trim len bytes from the end of the buffer. */


### PR DESCRIPTION
`tmp_nb` was used to transfer the flags from the old head netbuf in case there is a new head, but if that is necessary, it will have already been freed by the `while` block above.

Instead, we can save the flags as `tmp_flags` before freeing anything.