### PR TITLE
Use fnet_char_t * for strings

### DIFF
--- a/fnet_demos/common/fnet_application/fapp_shell.c
+++ b/fnet_demos/common/fnet_application/fapp_shell.c
@@ -333,7 +333,7 @@ void fapp_debug_cmd( fnet_shell_desc_t desc, fnet_index_t argc, fnet_char_t **ar
     {
         fnet_index_t    i = 0;
         fnet_ip6_addr_t addr_dns;
-        fnet_uint8_t    ip_str[FNET_IP_ADDR_STR_SIZE] = {0};
+        fnet_char_t    ip_str[FNET_IP_ADDR_STR_SIZE] = {0};
 
         while(fnet_netif_get_ip6_dns(fnet_netif_get_default(), i, &addr_dns ) == FNET_TRUE)
         {

--- a/fnet_stack/service/dhcp/fnet_dhcp.c
+++ b/fnet_stack/service/dhcp/fnet_dhcp.c
@@ -57,7 +57,7 @@ fnet_uint8_t *_fnet_dhcp_add_option(fnet_uint8_t *option_buffer, fnet_size_t opt
 * DESCRIPTION: Print DHCP header. For debug needs.
 ************************************************************************/
 #if FNET_CFG_DEBUG_TRACE_DHCP_SRV && FNET_CFG_DEBUG_TRACE
-void _fnet_dhcp_trace(fnet_uint8_t *str, fnet_dhcp_header_t *header )
+void _fnet_dhcp_trace(const fnet_char_t *str, fnet_dhcp_header_t *header )
 {
     fnet_char_t     ip_str[FNET_IP4_ADDR_STR_SIZE];
     fnet_index_t    i;

--- a/fnet_stack/service/dhcp/fnet_dhcp_cln.c
+++ b/fnet_stack/service/dhcp/fnet_dhcp_cln.c
@@ -247,7 +247,7 @@ static void _fnet_dhcp_cln_print_state( fnet_dhcp_cln_if_t *dhcp )
 ************************************************************************/
 static void _fnet_dhcp_cln_print_options( struct fnet_dhcp_cln_options_in *options )
 {
-    fnet_uint8_t ip_str[FNET_IP4_ADDR_STR_SIZE];
+    fnet_char_t ip_str[FNET_IP4_ADDR_STR_SIZE];
 
     FNET_DEBUG_DHCP_CLN("DHCP: Options:");
     FNET_DEBUG_DHCP_CLN(" message_type \t\t %02X", options->private_options.message_type);

--- a/fnet_stack/service/dhcp/fnet_dhcp_prv.h
+++ b/fnet_stack/service/dhcp/fnet_dhcp_prv.h
@@ -187,7 +187,7 @@ extern const fnet_uint8_t fnet_dhcp_magic_cookie[4];
 fnet_uint8_t *_fnet_dhcp_add_option(fnet_uint8_t *option_buffer, fnet_size_t option_buffer_size, fnet_uint8_t option_code, fnet_uint8_t option_length,  const void *option_value);
 
 #if FNET_CFG_DEBUG_TRACE_DHCP_SRV && FNET_CFG_DEBUG_TRACE
-void _fnet_dhcp_trace(fnet_uint8_t *str, fnet_dhcp_header_t *header);
+void _fnet_dhcp_trace(const fnet_char_t *str, fnet_dhcp_header_t *header);
 #else
 #define _fnet_dhcp_trace(str, header)    do{}while(0)
 #endif

--- a/fnet_stack/service/http/fnet_http_srv.c
+++ b/fnet_stack/service/http/fnet_http_srv.c
@@ -177,7 +177,7 @@ static void _fnet_http_srv_poll( void *http_if_p )
                     {
 #if FNET_CFG_DEBUG_HTTP && FNET_CFG_DEBUG
                         {
-                            fnet_uint8_t ip_str[FNET_IP_ADDR_STR_SIZE];
+                            fnet_char_t ip_str[FNET_IP_ADDR_STR_SIZE];
                             fnet_inet_ntop(foreign_addr.sa_family, (fnet_uint8_t *)(foreign_addr.sa_data), ip_str, sizeof(ip_str));
                             FNET_DEBUG_HTTP("");
                             FNET_DEBUG_HTTP("HTTP: RX Request From: %s; Port: %d.", ip_str, fnet_ntohs(foreign_addr.sa_port));

--- a/fnet_stack/service/telnet/fnet_telnet.c
+++ b/fnet_stack/service/telnet/fnet_telnet.c
@@ -335,7 +335,7 @@ static void _fnet_telnet_poll( void *telnet_if_p )
                     {
 #if FNET_CFG_DEBUG_TELNET && FNET_CFG_DEBUG
                         {
-                            fnet_uint8_t ip_str[FNET_IP_ADDR_STR_SIZE];
+                            fnet_char_t ip_str[FNET_IP_ADDR_STR_SIZE];
                             fnet_inet_ntop(foreign_addr.sa_family, foreign_addr.sa_data, ip_str, sizeof(ip_str));
                             FNET_DEBUG_TELNET("\nTELNET: New connection: %s; Port: %d.", ip_str, fnet_ntohs(foreign_addr.sa_port));
                         }

--- a/fnet_stack/stack/fnet_arp.c
+++ b/fnet_stack/stack/fnet_arp.c
@@ -52,7 +52,7 @@ static fnet_arp_entry_t *_fnet_arp_update_entry(fnet_netif_t *netif, fnet_ip4_ad
 static void _fnet_arp_ip4_addr_conflict(void *cookie);
 
 #if FNET_CFG_DEBUG_TRACE_ARP && FNET_CFG_DEBUG_TRACE
-static void fnet_arp_trace(fnet_uint8_t *str, fnet_arp_header_t *arp_hdr);
+static void fnet_arp_trace(const fnet_char_t *str, fnet_arp_header_t *arp_hdr);
 #else
 #define fnet_arp_trace(str, arp_hdr) \
     do                               \
@@ -582,10 +582,10 @@ fnet_bool_t fnet_arp_get_entry ( fnet_netif_desc_t netif_desc, fnet_index_t n, f
 * DESCRIPTION: Prints ARP header. For debugging purposes.
 *************************************************************************/
 #if FNET_CFG_DEBUG_TRACE_ARP && FNET_CFG_DEBUG_TRACE
-static void fnet_arp_trace(fnet_uint8_t *str, fnet_arp_header_t *arp_hdr)
+static void fnet_arp_trace(const fnet_char_t *str, fnet_arp_header_t *arp_hdr)
 {
-    fnet_uint8_t mac_str[FNET_MAC_ADDR_STR_SIZE];
-    fnet_uint8_t ip_str[FNET_IP4_ADDR_STR_SIZE];
+    fnet_char_t mac_str[FNET_MAC_ADDR_STR_SIZE];
+    fnet_char_t ip_str[FNET_IP4_ADDR_STR_SIZE];
 
     fnet_printf(FNET_SERIAL_ESC_FG_GREEN "%s", str); /* Print app-specific header.*/
     fnet_println("[ARP header]" FNET_SERIAL_ESC_ATTR_RESET);

--- a/fnet_stack/stack/fnet_icmp4.c
+++ b/fnet_stack/stack/fnet_icmp4.c
@@ -40,7 +40,7 @@ static void _fnet_icmp4_output( fnet_netif_t *netif, fnet_ip4_addr_t src_ip, fne
 static void _fnet_icmp4_notify_protocol(fnet_netif_t *netif, fnet_prot_notify_t prot_cmd, fnet_netbuf_t *nb );
 
 #if FNET_CFG_DEBUG_TRACE_ICMP4 && FNET_CFG_DEBUG_TRACE
-    void fnet_icmp4_trace(fnet_uint8_t *str, fnet_icmp4_header_t *icmpp_hdr);
+    void fnet_icmp4_trace(const fnet_char_t *str, fnet_icmp4_header_t *icmpp_hdr);
 #else
     #define fnet_icmp4_trace(str, icmp_hdr)  do{}while(0)
 #endif
@@ -419,7 +419,7 @@ void _fnet_icmp4_error( fnet_netif_t *netif, fnet_uint8_t type, fnet_uint8_t cod
 * DESCRIPTION: Prints an ICMP header. For debug needs only.
 *************************************************************************/
 #if FNET_CFG_DEBUG_TRACE_ICMP4 && FNET_CFG_DEBUG_TRACE
-void fnet_icmp4_trace(fnet_uint8_t *str, fnet_icmp4_header_t *icmp_hdr)
+void fnet_icmp4_trace(const fnet_char_t *str, fnet_icmp4_header_t *icmp_hdr)
 {
     fnet_printf(FNET_SERIAL_ESC_FG_GREEN"%s", str); /* Print app-specific header.*/
     fnet_println("[ICMP4 header]"FNET_SERIAL_ESC_ATTR_RESET);

--- a/fnet_stack/stack/fnet_igmp.c
+++ b/fnet_stack/stack/fnet_igmp.c
@@ -54,7 +54,7 @@
 static void _fnet_igmp_input(fnet_netif_t *netif, struct fnet_sockaddr *src_addr,  struct fnet_sockaddr *dest_addr, fnet_netbuf_t *nb, fnet_netbuf_t *ip4_nb);
 
 #if FNET_CFG_DEBUG_TRACE_IGMP && FNET_CFG_DEBUG_TRACE
-    static void _fnet_igmp_trace(fnet_uint8_t *str, fnet_igmp_header_t *icmpp_hdr);
+    static void _fnet_igmp_trace(const fnet_char_t *str, fnet_igmp_header_t *icmpp_hdr);
 #else
     #define _fnet_igmp_trace(str, icmp_hdr)  do {}while(0)
 #endif
@@ -232,9 +232,9 @@ void _fnet_igmp_leave( fnet_netif_t *netif, fnet_ip4_addr_t  group_addr )
 * DESCRIPTION: Prints an IGMP header. For debug needs only.
 *************************************************************************/
 #if FNET_CFG_DEBUG_TRACE_IGMP && FNET_CFG_DEBUG_TRACE
-static void _fnet_igmp_trace(fnet_uint8_t *str, fnet_igmp_header_t *igmp_hdr)
+static void _fnet_igmp_trace(const fnet_char_t *str, fnet_igmp_header_t *igmp_hdr)
 {
-    fnet_uint8_t ip_str[FNET_IP4_ADDR_STR_SIZE];
+    fnet_char_t ip_str[FNET_IP4_ADDR_STR_SIZE];
 
     fnet_printf(FNET_SERIAL_ESC_FG_GREEN"%s", str); /* Print app-specific header.*/
     fnet_println("[IGMP header]"FNET_SERIAL_ESC_ATTR_RESET);

--- a/fnet_stack/stack/fnet_ip4.c
+++ b/fnet_stack/stack/fnet_ip4.c
@@ -74,7 +74,7 @@ static fnet_bool_t _fnet_ip4_addr_is_onlink(fnet_netif_t *netif, fnet_ip4_addr_t
 #endif
 
 #if FNET_CFG_DEBUG_TRACE_IP4 && FNET_CFG_DEBUG_TRACE
-    static void _fnet_ip4_trace(fnet_uint8_t *str, fnet_ip4_header_t *ip_hdr);
+    static void _fnet_ip4_trace(const fnet_char_t *str, fnet_ip4_header_t *ip_hdr);
 #else
     #define _fnet_ip4_trace(str, ip_hdr)  do{}while(0)
 #endif
@@ -1387,9 +1387,9 @@ fnet_error_t _fnet_ip4_setsockopt(struct _fnet_socket_if_t  *sock, fnet_socket_o
 * DESCRIPTION: Prints an IP header. For debug needs only.
 *************************************************************************/
 #if FNET_CFG_DEBUG_TRACE_IP4 && FNET_CFG_DEBUG_TRACE
-static void _fnet_ip4_trace(fnet_uint8_t *str, fnet_ip4_header_t *ip_hdr)
+static void _fnet_ip4_trace(const fnet_char_t *str, fnet_ip4_header_t *ip_hdr)
 {
-    fnet_uint8_t ip_str[FNET_IP4_ADDR_STR_SIZE];
+    fnet_char_t ip_str[FNET_IP4_ADDR_STR_SIZE];
 
     fnet_printf(FNET_SERIAL_ESC_FG_GREEN"%s", str); /* Print app-specific header.*/
     fnet_println("[IPv4 header]"FNET_SERIAL_ESC_ATTR_RESET);

--- a/fnet_stack/stack/fnet_nd6.c
+++ b/fnet_stack/stack/fnet_nd6.c
@@ -1675,7 +1675,7 @@ void _fnet_nd6_router_advertisement_receive(struct fnet_netif *netif, fnet_ip6_a
                 fnet_nd6_prefix_entry_t *prefix_entry;
 
 #if FNET_CFG_DEBUG_IP6 && FNET_CFG_DEBUG
-                fnet_uint8_t numaddr[FNET_IP6_ADDR_STR_SIZE] = {0};
+                fnet_char_t numaddr[FNET_IP6_ADDR_STR_SIZE] = {0};
                 fnet_inet_ntop(AF_INET6, (fnet_uint8_t *)&nd_option_prefix[i]->prefix, numaddr, sizeof(numaddr));
 
                 fnet_println("Prefix[%d]= %s \n", i, numaddr);
@@ -2055,7 +2055,7 @@ static void _fnet_nd6_dad_timer(fnet_netif_t *netif )
 
 #if FNET_CFG_DEBUG_IP6 && FNET_CFG_DEBUG
                     {
-                        fnet_uint8_t numaddr[FNET_IP6_ADDR_STR_SIZE] = {0};
+                        fnet_char_t numaddr[FNET_IP6_ADDR_STR_SIZE] = {0};
                         fnet_inet_ntop(AF_INET6, (fnet_uint8_t *)&addr_info->address, numaddr, sizeof(numaddr));
                         fnet_println("%s is PREFERED NOW\n", numaddr);
                     }
@@ -2081,7 +2081,7 @@ static void _fnet_nd6_dad_failed(fnet_netif_t *netif, fnet_netif_ip6_addr_t *add
 
 #if FNET_CFG_DEBUG_IP6 && FNET_CFG_DEBUG
     {
-        fnet_uint8_t numaddr[FNET_IP6_ADDR_STR_SIZE] = {0};
+        fnet_char_t numaddr[FNET_IP6_ADDR_STR_SIZE] = {0};
         fnet_inet_ntop(AF_INET6, (fnet_uint8_t *)&addr_info->address, numaddr, sizeof(numaddr));
         fnet_println("%s DAD is FAILED!!!!\n", numaddr);
     }

--- a/fnet_stack/stack/fnet_tcp.c
+++ b/fnet_stack/stack/fnet_tcp.c
@@ -113,7 +113,7 @@ static void _fnet_tcp_drain( void );
 static void _fnet_tcp_initial_seq_number_update( void );
 
 #if FNET_CFG_DEBUG_TRACE_TCP && FNET_CFG_DEBUG_TRACE
-    void _fnet_tcp_trace(fnet_uint8_t *str, fnet_tcp_header_t *tcp_hdr);
+    void _fnet_tcp_trace(const fnet_char_t *str, fnet_tcp_header_t *tcp_hdr);
 #else
     #define _fnet_tcp_trace(str, tcp_hdr)    do{}while(0)
 #endif
@@ -4108,7 +4108,7 @@ static fnet_uint32_t _fnet_tcp_get_size( fnet_uint32_t pos1, fnet_uint32_t pos2 
 * DESCRIPTION: Prints TCP header. For debugging purposes.
 *************************************************************************/
 #if FNET_CFG_DEBUG_TRACE_TCP && FNET_CFG_DEBUG_TRACE
-void _fnet_tcp_trace(fnet_uint8_t *str, fnet_tcp_header_t *tcp_hdr)
+void _fnet_tcp_trace(const fnet_char_t *str, fnet_tcp_header_t *tcp_hdr)
 {
     fnet_printf(FNET_SERIAL_ESC_FG_GREEN"%s", str); /* Print app-specific header.*/
     fnet_println("[TCP header]"FNET_SERIAL_ESC_ATTR_RESET);

--- a/fnet_stack/stack/fnet_udp.c
+++ b/fnet_stack/stack/fnet_udp.c
@@ -46,7 +46,7 @@ static void _fnet_udp_release(void);
 static fnet_error_t _fnet_udp_output(struct fnet_sockaddr *src_addr, const struct fnet_sockaddr *dest_addr, fnet_socket_option_t *sockoption, fnet_netbuf_t *nb );
 
 #if FNET_CFG_DEBUG_TRACE_UDP && FNET_CFG_DEBUG_TRACE
-    static void _fnet_udp_trace(fnet_uint8_t *str, fnet_udp_header_t *udp_hdr);
+    static void _fnet_udp_trace(const fnet_char_t *str, fnet_udp_header_t *udp_hdr);
 #else
     #define _fnet_udp_trace(str, udp_hdr)    do{}while(0)
 #endif
@@ -664,17 +664,17 @@ static void _fnet_udp_control_input(fnet_prot_notify_t command, struct fnet_sock
 * DESCRIPTION: Prints UDP header. For debugging purposes.
 *************************************************************************/
 #if FNET_CFG_DEBUG_TRACE_UDP && FNET_CFG_DEBUG_TRACE
-static void _fnet_udp_trace(fnet_uint8_t *str, fnet_udp_header_t *udp_hdr)
+static void _fnet_udp_trace(const fnet_char_t *str, fnet_udp_header_t *udp_hdr)
 {
 
     fnet_printf(FNET_SERIAL_ESC_FG_GREEN"%s", str); /* Print app-specific header.*/
     fnet_println("[UDP header]"FNET_SERIAL_ESC_ATTR_RESET);
     fnet_println("+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+");
-    fnet_println("|(SrcPort)                  "FNET_SERIAL_ESC_FG_BLUE"%3u"FNET_SERIAL_ESC_ATTR_RESET" |(DestPort)                 "FNET_SERIAL_ESC_FG_BLUE"%3u"FNET_SERIAL_ESC_ATTR_RESET" |",
+    fnet_println("|(SrcPort)                "FNET_SERIAL_ESC_FG_BLUE"%5u"FNET_SERIAL_ESC_ATTR_RESET" |(DestPort)               "FNET_SERIAL_ESC_FG_BLUE"%5u"FNET_SERIAL_ESC_ATTR_RESET" |",
                  fnet_ntohs(udp_hdr->source_port),
                  fnet_ntohs(udp_hdr->destination_port));
     fnet_println("+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+");
-    fnet_println("|(Lenghth)                  "FNET_SERIAL_ESC_FG_BLUE"%3u"FNET_SERIAL_ESC_ATTR_RESET" |(Checksum)              0x%04X |",
+    fnet_println("|(Lenghth)                "FNET_SERIAL_ESC_FG_BLUE"%5u"FNET_SERIAL_ESC_ATTR_RESET" |(Checksum)              0x%04X |",
                  fnet_ntohs(udp_hdr->length),
                  fnet_ntohs(udp_hdr->checksum));
     fnet_println("+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+");


### PR DESCRIPTION
Strings are arrays of char (and thus fnet_char_t) in C and the compiler may complain if they are unsigned. Also "XX" is placed in flash and is therefore of type const char.

It isn't an issue unless enabling debug information. So this patch updates the cases in the debug and trace output.

Also, UDP port numbers goes up to 65535, which is 5 digits. So change the output to also align properly for numbers above 999.